### PR TITLE
SSMprotocol2::getAdjustmentValue(): fix 16 bit values

### DIFF
--- a/src/SSMprotocol2.cpp
+++ b/src/SSMprotocol2.cpp
@@ -436,7 +436,7 @@ bool SSMprotocol2::getAdjustmentValue(unsigned char index, unsigned int *rawValu
 	datalen = 1;
 	if (_adjustments.at(index).AddrHigh > 0)
 	{
-		dataaddr[1] = _adjustments.at(index).AddrLow;
+		dataaddr[1] = _adjustments.at(index).AddrHigh;
 		datalen++;
 	}
 	// Read data from control unit:


### PR DESCRIPTION
Use the correct address for the high byte of 16 bit values.